### PR TITLE
Respect `ignoreDifferences` on initial sync

### DIFF
--- a/rbacmultitenancydemo/application-openshift-setup.yaml
+++ b/rbacmultitenancydemo/application-openshift-setup.yaml
@@ -16,6 +16,7 @@ spec:
   syncPolicy:
     syncOptions:
     - CreateNamespace=true
+    - RespectIgnoreDifferences=true
     automated:
       selfHeal: true
       prune: true


### PR DESCRIPTION
Apparently `ignoreDifferences` isn't respected when applying initially. This setting changes that behavior.

Reference: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs